### PR TITLE
bootloader installation: fix use of unassigned variable

### DIFF
--- a/src/modules/bootldr/main.py
+++ b/src/modules/bootldr/main.py
@@ -132,7 +132,7 @@ def install_bootloader(boot_loader, fw_type):
                 boot_p = boot_device[-1:]
                 device = boot_device[:-1]
                 print(device)
-        subprocess.call(["sgdisk", "--typecode=%s:EF00" % boot_p, "%s" % device])
+                subprocess.call(["sgdisk", "--typecode=%s:EF00" % boot_p, "%s" % device])
         subprocess.call(
             ["bootctl", "--path=%s/boot" % install_path, "install"])
         create_conf(uuid, conf_path)


### PR DESCRIPTION
the installation of KAOS did not work until I fixed the bootloader installation