### PR TITLE
Allow bootldr to work with devices where boot partition have a number > 9 like /dev/sda10

### DIFF
--- a/src/modules/bootldr/main.py
+++ b/src/modules/bootldr/main.py
@@ -184,8 +184,8 @@ def install_bootloader(boot_loader, fw_type):
             if partition["mountPoint"] == "/boot":
                 libcalamares.utils.debug(partition["device"])
                 boot_device = partition["device"]
-                boot_p = boot_device[-1:]
-                device = boot_device[:-1]
+                boot_p = ''.join([s for s in boot_device if s.isdigit()])
+                device = b''.join([s for s in boot_device if not s.isdigit()])
                 if boot_device.startswith('/dev/nvme'):
                     device = boot_device[:-2]
 

--- a/src/modules/bootldr/main.py
+++ b/src/modules/bootldr/main.py
@@ -185,7 +185,7 @@ def install_bootloader(boot_loader, fw_type):
                 libcalamares.utils.debug(partition["device"])
                 boot_device = partition["device"]
                 boot_p = ''.join([s for s in boot_device if s.isdigit()])
-                device = b''.join([s for s in boot_device if not s.isdigit()])
+                device = ''.join([s for s in boot_device if not s.isdigit()])
                 if boot_device.startswith('/dev/nvme'):
                     device = boot_device[:-2]
 


### PR DESCRIPTION
Implement requested (by me) enhancement: https://github.com/KaOSx/calamares/issues/87